### PR TITLE
Fixing secreName size bigger than 63 chars

### DIFF
--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -228,11 +228,11 @@ func ingressName(appName string) string {
 
 func secretName(appName, certName string) string {
 	fuzCertName := certName
-	if len(certName) > 39 {
+	if len(certName) > 16 {
 		algorithm := sha1.New()
 		_, err := algorithm.Write([]byte(certName))
 		if err == nil {
-			fuzCertName = hex.EncodeToString(algorithm.Sum(nil))
+			fuzCertName = hex.EncodeToString(algorithm.Sum(nil))[0:15]
 		}
 	}
 	return "kr-" + appName + "-" + fuzCertName

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -5,6 +5,8 @@
 package kubernetes
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
@@ -225,7 +227,15 @@ func ingressName(appName string) string {
 }
 
 func secretName(appName, certName string) string {
-	return "kubernetes-router-" + appName + "-" + certName + "-secret"
+	fuzCertName := certName
+	if len(certName) > 39 {
+		algorithm := sha1.New()
+		_, err := algorithm.Write([]byte(certName))
+		if err == nil {
+			fuzCertName = hex.EncodeToString(algorithm.Sum(nil))
+		}
+	}
+	return "kr-" + appName + "-" + fuzCertName
 }
 
 func annotationWithPrefix(suffix string) string {

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -228,7 +228,7 @@ func ingressName(appName string) string {
 
 func secretName(appName, certName string) string {
 	hashedAppCertName := appName + "-" + certName
-	if (len(hashedAppCertName)) > 59 {
+	if (len(hashedAppCertName)) > 49 {
 		algorithm := sha1.New()
 		_, err := algorithm.Write([]byte(hashedAppCertName))
 		if err == nil {

--- a/kubernetes/ingress_test.go
+++ b/kubernetes/ingress_test.go
@@ -26,6 +26,27 @@ func createFakeService() IngressService {
 	}
 }
 
+func TestSecretName(t *testing.T) {
+	appName := "tsuru-dashboard"
+	certName := "biiigerdomain.cloud.evenbiiiiiiiiigerrrrr.com"
+	sName := secretName(appName, certName)
+	if sName != "kr-tsuru-dashboard-820cd9555057448cf3183d001e997a4049d3c881" {
+		t.Errorf("SecretName Got %v.", sName)
+	}
+	if len(sName) > 63 {
+		t.Errorf("SecretName too big, something went wrong.")
+	}
+	appName = "tsuru-dashboard"
+	certName = "domain.com"
+	sName = secretName(appName, certName)
+	if sName != "kr-tsuru-dashboard-domain.com" {
+		t.Errorf("SecretName Got %v.", sName)
+	}
+	if len(sName) > 63 {
+		t.Errorf("SecretName too big, something went wrong.")
+	}
+}
+
 func TestCreate(t *testing.T) {
 	svc := createFakeService()
 	svc.Labels = map[string]string{"controller": "my-controller", "XPTO": "true"}

--- a/kubernetes/ingress_test.go
+++ b/kubernetes/ingress_test.go
@@ -30,7 +30,7 @@ func TestSecretName(t *testing.T) {
 	appName := "tsuru-dashboard"
 	certName := "biiigerdomain.cloud.evenbiiiiiiiiigerrrrr.com"
 	sName := secretName(appName, certName)
-	if sName != "kr-tsuru-dashboard-820cd9555057448cf3183d001e997a4049d3c881" {
+	if sName != "kr-tsuru-dashboard-820cd9555057448" {
 		t.Errorf("SecretName Got %v.", sName)
 	}
 	if len(sName) > 63 {

--- a/kubernetes/ingress_test.go
+++ b/kubernetes/ingress_test.go
@@ -30,7 +30,7 @@ func TestSecretName(t *testing.T) {
 	appName := "tsuru-dashboard"
 	certName := "biiigerdomain.cloud.evenbiiiiiiiiigerrrrr.com"
 	sName := secretName(appName, certName)
-	if sName != "kr-tsuru-dashboard-820cd9555057448" {
+	if sName != "kr-742c4ad94b87ba0d5895d073540d9629d86b97da" {
 		t.Errorf("SecretName Got %v.", sName)
 	}
 	if len(sName) > 63 {

--- a/kubernetes/service.go
+++ b/kubernetes/service.go
@@ -24,6 +24,7 @@ const (
 
 	defaultServicePort = 8888
 	appLabel           = "tsuru.io/app-name"
+	domainLabel        = "tsuru.io/domain-name"
 	processLabel       = "tsuru.io/app-process"
 	swapLabel          = "tsuru.io/swapped-with"
 	appPoolLabel       = "tsuru.io/app-pool"


### PR DESCRIPTION
As the certName is the domain or cname it can get bigger than 63 chars which is the supported by kubernetes. 

Fixing secreName size bigger than 63 chars.